### PR TITLE
Fixes macos tests in GitHub actions. 

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -26,6 +26,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install numpy
+        alias gfortran=gfortran-8
         pip install .
       if: matrix.os == 'macos-10.15'
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -17,7 +17,6 @@ jobs:
     - name: Install dependencies
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory
-        $CONDA/bin/conda activate base
         $CONDA/bin/conda list
     - name: Lint with flake8
       run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -40,8 +40,7 @@ jobs:
       if: matrix.os == 'macos-10.15'
 
     -name: macos run tests
-      run: |
-        $CONDA/bin/pytest tests/
+      run: $CONDA/bin/pytest tests/
       if: matrix.os == 'macos-10.15'
 
     - name: windows install fortran

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -35,7 +35,7 @@ jobs:
         $CONDA/bin/conda install gfortran_osx-64 numpy wheel
         echo $CC
         $CONDA/bin/gfortran -v
-        cp -f $CONDA/bin/gfortran /usr/local/bin/gfortran
+        ln -s $CONDA/bin/gfortran /usr/local/bin/gfortran
         $CONDA/bin/python -m pip install .
       if: matrix.os == 'macos-10.15'
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -39,7 +39,6 @@ jobs:
 
     - name: macos run tests
       run: |
-        pwd
         $CONDA/bin/python -m pytest ./
       working-directory: $HOME/gripy/gripy/tests/
       if: matrix.os == 'macos-10.15'

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       max-parallel: 5
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -35,7 +35,14 @@ jobs:
         ln -s $CONDA/bin/gfortran /usr/local/bin/gfortran
         $CONDA/bin/python -m pip install .
         $CONDA/bin/python -m pip install -r requirements-test.txt
-        $CONDA/bin/python -m pytest tests/
+      if: matrix.os == 'macos-10.15'
+
+    -name: macos run tests
+      working-directory:
+        $HOME/gripy/gripy/tests/
+      run: |
+        pwd
+        $CONDA/bin/python -m pytest ./
       if: matrix.os == 'macos-10.15'
 
     - name: windows install fortran

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -37,11 +37,11 @@ jobs:
         $CONDA/bin/python -m pip install -r requirements-test.txt
       if: matrix.os == 'macos-10.15'
 
-    -name: macos run tests
-      working-directory: $HOME/gripy/gripy/tests/
+    - name: macos run tests
       run: |
         pwd
         $CONDA/bin/python -m pytest ./
+      working-directory: $HOME/gripy/gripy/tests/
       if: matrix.os == 'macos-10.15'
 
     - name: windows install fortran

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-10.15 ]
-        python: [3.6, 3.7, 3.8,]
+        os: [ macos-10.15 ]
+        python: [3.7]
 
     steps:
     - uses: actions/checkout@v1
@@ -25,7 +25,8 @@ jobs:
     - name: macos install fortran
       run: |
         python -m pip install --upgrade pip
-        pip install --global-option='--fcompiler=gfortran-8' .
+        pip install numpy
+        pip install .
       if: matrix.os == 'macos-10.15'
 
     - name: windows install fortran

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -31,11 +31,9 @@ jobs:
 
     - name: macos install fortran
       run: |
-        $CONDA/bin/conda init bash
-        $CONDA/bin/conda activate base
         $CONDA/bin/conda install gfortran_osx-64 numpy wheel
-        python -m pip install --upgrade pip
-        pip install .
+        # $CONDA/bin/python -m pip install --upgrade pip
+        $CONDA/bin/python -m pip install .
       if: matrix.os == 'macos-10.15'
 
     - name: windows install fortran

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -12,9 +12,9 @@ jobs:
         python: [3.7]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
     
@@ -26,7 +26,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install numpy wheel
-        conda install gfortran_osx-64
+        $CONDA/bin/conda install gfortran_osx-64
         pip install .
       if: matrix.os == 'macos-10.15'
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         sudo chown -R $UID $CONDA
         echo $SHELL
-        $CONDA/bin/conda init $SHELL
+        $CONDA/bin/conda init bash
       if: matrix.os == 'macos-10.15'
 
     - name: macos install fortran

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -31,9 +31,12 @@ jobs:
 
     - name: macos install fortran
       run: |
-        brew install gcc
-        # $CONDA/bin/conda install gfortran_osx-64 numpy wheel
-        # $CONDA/bin/python -m pip install .
+        # brew install gcc
+        $CONDA/bin/conda install gfortran_osx-64 numpy wheel
+        echo $CC
+        $CONDA/bin/gfortran
+        cp -f $CONDA/bin/gfortran /usr/local/bin/gfortran
+        $CONDA/bin/python -m pip install .
       if: matrix.os == 'macos-10.15'
 
     - name: windows install fortran

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -31,12 +31,11 @@ jobs:
 
     - name: macos install fortran
       run: |
-        # brew install gcc
         $CONDA/bin/conda install gfortran_osx-64 numpy wheel
-        echo $CC
-        $CONDA/bin/gfortran -v
         ln -s $CONDA/bin/gfortran /usr/local/bin/gfortran
         $CONDA/bin/python -m pip install .
+        $CONDA/bin/python -m pip install -r requirements-test.txt
+        $CONDA/bin/python -m pytest tests/
       if: matrix.os == 'macos-10.15'
 
     - name: windows install fortran
@@ -50,7 +49,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install . 
         pip install -r requirements-test.txt
+      if: matrix.os != 'macos-10.15'
     - name: Test with pytest
       run: |
         pip install pytest
         pytest tests/
+      if: matrix.os != 'macos-10.15'
+

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ macos-10.15 ]
-        python: [3.7]
+        os: [ ubuntu-latest, macos-10.15 ]
+        python: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
         $CONDA/bin/conda init bash
       if: matrix.os == 'macos-10.15'
 
-    - name: macos install fortran
+    - name: macos install dependencies
       run: |
         $CONDA/bin/conda install gfortran_osx-64 numpy wheel
         ln -s $CONDA/bin/gfortran /usr/local/bin/gfortran
@@ -38,10 +38,8 @@ jobs:
       if: matrix.os == 'macos-10.15'
 
     -name: macos run tests
-      working-directory: $HOME/gripy/gripy/tests/
       run: |
-        pwd
-        $CONDA/bin/python -m pytest ./
+        $CONDA/bin/pytest tests/
       if: matrix.os == 'macos-10.15'
 
     - name: windows install fortran
@@ -56,6 +54,7 @@ jobs:
         pip install . 
         pip install -r requirements-test.txt
       if: matrix.os != 'macos-10.15'
+
     - name: Test with pytest
       run: |
         pip install pytest

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -23,7 +23,9 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
 
     - name: macos install fortran
-      run: brew install gcc
+      run: |
+        python -m pip install --upgrade pip
+        pip install --global-option='--fcompiler=gfortran-8' .
       if: matrix.os == 'macos-10.15'
 
     - name: windows install fortran
@@ -35,7 +37,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .
+        pip install . 
         pip install -r requirements-test.txt
     - name: Test with pytest
       run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -31,6 +31,7 @@ jobs:
 
     - name: macos install fortran
       run: |
+        $CONDA/bin/conda init bash
         $CONDA/bin/conda activate base
         $CONDA/bin/conda install gfortran_osx-64 numpy wheel
         python -m pip install --upgrade pip

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -35,11 +35,9 @@ jobs:
         ln -s $CONDA/bin/gfortran /usr/local/bin/gfortran
         $CONDA/bin/python -m pip install .
         $CONDA/bin/python -m pip install -r requirements-test.txt
-        echo $PWD
-        $CONDA/bin/pytest tests/
       if: matrix.os == 'macos-10.15'
 
-    -name: macos run tests
+    - name: macos run tests
       run: $CONDA/bin/pytest tests/
       if: matrix.os == 'macos-10.15'
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -17,7 +17,8 @@ jobs:
     - name: Install dependencies
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory
-        $CONDA/bin/conda env update --file environment.yml --name base
+        $CONDA/bin/conda activate base
+        $CONDA/bin/conda list
     - name: Lint with flake8
       run: |
         $CONDA/bin/conda install flake8

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -31,9 +31,9 @@ jobs:
 
     - name: macos install fortran
       run: |
-        $CONDA/bin/conda install gfortran_osx-64 numpy wheel
-        # $CONDA/bin/python -m pip install --upgrade pip
-        $CONDA/bin/python -m pip install .
+        brew install gcc
+        # $CONDA/bin/conda install gfortran_osx-64 numpy wheel
+        # $CONDA/bin/python -m pip install .
       if: matrix.os == 'macos-10.15'
 
     - name: windows install fortran

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,47 +1,31 @@
-name: gripy Unit Tests
+name: Python Package using Conda
 
 on: [push]
 
 jobs:
-  unit_tests:
-
-    runs-on: ${{ matrix.os }}
+  build-linux:
+    runs-on: ubuntu-latest
     strategy:
-      matrix:
-        os: [ macos-10.15 ]
-        python: [3.7]
+      max-parallel: 5
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python }}
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python }}
-    
-    - name: ubuntu install fortran
-      run: sudo apt install gfortran
-      if: matrix.os == 'ubuntu-latest'
-
-    - name: macos install fortran
-      run: |
-        python -m pip install --upgrade pip
-        pip install numpy wheel
-        $CONDA/bin/conda install gfortran_osx-64
-        pip install .
-      if: matrix.os == 'macos-10.15'
-
-    - name: windows install fortran
-      run: |
-        choco install mingw
-        pip install numpy==1.15
-      if: matrix.os == 'windows-latest'
-
+        python-version: 3.8
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install . 
-        pip install -r requirements-test.txt
+        # $CONDA is an environment variable pointing to the root of the miniconda directory
+        $CONDA/bin/conda env update --file environment.yml --name base
+    - name: Lint with flake8
+      run: |
+        $CONDA/bin/conda install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        $CONDA/bin/flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        $CONDA/bin/flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pip install pytest
-        pytest tests/
+        conda install pytest
+        $CONDA/bin/pytest

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,8 +24,8 @@ jobs:
 
     - name: Fix Conda permissions on macOS
       run: sudo chown -R $UID $CONDA
-      if: matrix.os == 'macos-latest'
-      
+      if: matrix.os == 'macos-10.15'
+
     - name: macos install fortran
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,6 +14,9 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
+    - name: Fix Conda permissions on macOS
+      run: sudo chown -R $UID $CONDA
+      if: matrix.os == 'macos-latest'
     - name: Install dependencies
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -35,12 +35,13 @@ jobs:
         ln -s $CONDA/bin/gfortran /usr/local/bin/gfortran
         $CONDA/bin/python -m pip install .
         $CONDA/bin/python -m pip install -r requirements-test.txt
+        echo $PWD
+        $CONDA/bin/pytest tests/
       if: matrix.os == 'macos-10.15'
 
     - name: macos run tests
       run: |
-        $CONDA/bin/python -m pytest ./
-      working-directory: $HOME/gripy/gripy/tests/
+        $CONDA/bin/python -m pytest $HOME/gripy/gripy/tests/
       if: matrix.os == 'macos-10.15'
 
     - name: windows install fortran

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -4,10 +4,13 @@ on: [push]
 
 jobs:
   build-linux:
-    runs-on: macos-latest
     strategy:
       max-parallel: 5
-
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -38,8 +38,7 @@ jobs:
       if: matrix.os == 'macos-10.15'
 
     -name: macos run tests
-      working-directory:
-        $HOME/gripy/gripy/tests/
+      working-directory: $HOME/gripy/gripy/tests/
       run: |
         pwd
         $CONDA/bin/python -m pytest ./

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -25,8 +25,9 @@ jobs:
     - name: macos install fortran
       run: |
         python -m pip install --upgrade pip
-        pip install numpy
+        pip install numpy wheel
         alias gfortran=gfortran-8
+        gfortran -v
         pip install .
       if: matrix.os == 'macos-10.15'
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,37 +1,51 @@
-name: Python Package using Conda
+name: gripy Unit Tests
 
 on: [push]
 
 jobs:
-  build-linux:
-    strategy:
-      max-parallel: 5
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
+  unit_tests:
+
     runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ macos-10.15 ]
+        python: [3.7]
+
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: ${{ matrix.python }}
+    
+    - name: ubuntu install fortran
+      run: sudo apt install gfortran
+      if: matrix.os == 'ubuntu-latest'
+
     - name: Fix Conda permissions on macOS
       run: sudo chown -R $UID $CONDA
       if: matrix.os == 'macos-latest'
+      
+    - name: macos install fortran
+      run: |
+        python -m pip install --upgrade pip
+        pip install numpy wheel
+        $CONDA/bin/conda install gfortran_osx-64
+        pip install .
+      if: matrix.os == 'macos-10.15'
+
+    - name: windows install fortran
+      run: |
+        choco install mingw
+        pip install numpy==1.15
+      if: matrix.os == 'windows-latest'
+
     - name: Install dependencies
       run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        $CONDA/bin/conda list
-    - name: Lint with flake8
-      run: |
-        $CONDA/bin/conda install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        $CONDA/bin/flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        $CONDA/bin/flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        python -m pip install --upgrade pip
+        pip install . 
+        pip install -r requirements-test.txt
     - name: Test with pytest
       run: |
-        conda install pytest
-        $CONDA/bin/pytest
+        pip install pytest
+        pytest tests/

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -34,7 +34,7 @@ jobs:
         # brew install gcc
         $CONDA/bin/conda install gfortran_osx-64 numpy wheel
         echo $CC
-        $CONDA/bin/gfortran
+        $CONDA/bin/gfortran -v
         cp -f $CONDA/bin/gfortran /usr/local/bin/gfortran
         $CONDA/bin/python -m pip install .
       if: matrix.os == 'macos-10.15'

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -26,8 +26,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install numpy wheel
-        alias gfortran=gfortran-8
-        gfortran -v
+        conda install gfortran_osx-64
         pip install .
       if: matrix.os == 'macos-10.15'
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -23,14 +23,17 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
 
     - name: Fix Conda permissions on macOS
-      run: sudo chown -R $UID $CONDA
+      run: |
+        sudo chown -R $UID $CONDA
+        echo $SHELL
+        $CONDA/bin/conda init $SHELL
       if: matrix.os == 'macos-10.15'
 
     - name: macos install fortran
       run: |
+        $CONDA/bin/conda activate base
+        $CONDA/bin/conda install gfortran_osx-64 numpy wheel
         python -m pip install --upgrade pip
-        pip install numpy wheel
-        $CONDA/bin/conda install gfortran_osx-64
         pip install .
       if: matrix.os == 'macos-10.15'
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,3 @@
 pytest
 hypothesis
 pupygrib
-wheel


### PR DESCRIPTION
what a nightmare.  
Default gfortran throws errors for some reason.  
Conda in workflows is sketchy, but it works now.  Don't touch it.  Walk away slowly. 
also: pytest ./tests/ != python -m pytest ./tests/ 