### PR TITLE
Include Wheels for Mac builds

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -6,7 +6,7 @@ on:
     - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
-  build-n-publish:
+  build-n-publish_linux:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     runs-on: ubuntu-latest
     steps:
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-         pip install twine flake8
+        pip install twine flake8
     - name: Lint with flake8 for syntax errors
       run: |
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
@@ -26,7 +26,7 @@ jobs:
     - name: Build manylinux Python wheels
       uses: RalfG/python-wheels-manylinux-build@v0.2-manylinux1_x86_64
       with:
-        python-versions: 'cp36-cp36m cp37-cp37m'
+        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38m cp38-cp39m'
         build-requirements: ''
         package-path: ''
     - uses: actions/upload-artifact@v1
@@ -40,3 +40,44 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_GLOBAL_PASSWORD }}
       run: |
         twine upload -u ${TWINE_USERNAME} -p ${TWINE_PASSWORD} wheelhouse/gripy*-manylinux*.whl
+
+  build-n-publish_macos:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    strategy:
+      matrix:
+        python: [ 3.6,3.7, 3.8 ]
+    runs-on: macos-latest
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+
+    - name: Fix Conda permissions on macOS
+      run: |
+        sudo chown -R $UID $CONDA
+        echo $SHELL
+        $CONDA/bin/conda init bash
+
+    - name: macos install dependencies
+      env:
+        DELOCATE_LIBRARY_PATH: /usr/local/miniconda/lib
+      run: |
+        $CONDA/bin/python -m pip install git+https://github.com/abrammer/delocate.git
+        $CONDA/bin/conda install gfortran_osx-64 numpy wheel
+        ln -s $CONDA/bin/gfortran /usr/local/bin/gfortran
+        $CONDA/bin/python -m pip install .
+        $CONDA/bin/python -m pip install -r requirements-test.txt
+        $CONDA/bin/python setup.py bdist_wheel
+        echo "Start delocate"
+        $CONDA/bin/delocate-wheel -w fixed_wheels -v  dist/gripy-*
+    - name: Publish wheels to PyPI
+      if: github.event.base_ref == 'refs/heads/master'
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_GLOBAL_PASSWORD }}
+      run: |
+        twine upload -u ${TWINE_USERNAME} -p ${TWINE_PASSWORD} fixed_wheels/gripy*-macosx*.whl

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Build manylinux Python wheels
       uses: RalfG/python-wheels-manylinux-build@v0.2-manylinux1_x86_64
       with:
-        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38m cp38-cp39m'
+        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38m cp39-cp39m'
         build-requirements: ''
         package-path: ''
     - uses: actions/upload-artifact@v1

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -37,7 +37,9 @@ jobs:
         $CONDA/bin/python -m pip install -r requirements-test.txt
         $CONDA/bin/python -m pip install delocate
         $CONDA/bin/python setup.py bdist_wheel
+        echo "List delocate"
         $CONDA/bin/delocate-listdeps dist/gripy-*
+        echo "Start delocate"
         $CONDA/bin/delocate-wheel -w fixed_wheels -v  dist/gripy-*
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Build wheels
       env:
         # CIBW_BEFORE_BUILD: scripts/build-openssl /tmp/vendor
-        # CIBW_ENVIRONMENT: AIOQUIC_SKIP_TESTS=ipv6,loss CFLAGS=-I/tmp/vendor/include LDFLAGS=-L/tmp/vendor/lib
+        CIBW_ENVIRONMENT: "PATH=$PATH:$CONDA/bin"
         CIBW_SKIP: cp27-* cp33-* cp34-* cp35-* pp27-*
         # CIBW_TEST_COMMAND: $CONDA/bin/pytest discover -t {project} -s {project}/tests
       run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -35,6 +35,7 @@ jobs:
         ln -s $CONDA/bin/gfortran /usr/local/bin/gfortran
         $CONDA/bin/python -m pip install .
         $CONDA/bin/python -m pip install -r requirements-test.txt
+        $CONDA/bin/python -m pip install delocate
       if: matrix.os == 'macos-10.15'
 
     - name: macos run tests
@@ -42,19 +43,14 @@ jobs:
       if: matrix.os == 'macos-10.15'
 
     - name: Build wheels
-      env:
-        # CIBW_BEFORE_BUILD: scripts/build-openssl /tmp/vendor
-        CIBW_ENVIRONMENT: "PATH=$PATH:$CONDA/bin CFLAGS=-I$CONDA/include LDFLAGS=-L$CONDA/lib"
-        CIBW_SKIP: cp27-* cp3* pp27-* pp34-* pp35-* pp36-* pp38-* pp39-*
-        # CIBW_TEST_COMMAND: $CONDA/bin/pytest discover -t {project} -s {project}/tests
       run: |
-        $CONDA/bin/pip install cibuildwheel
-        $CONDA/bin/cibuildwheel --output-dir ./wheelhouse
+        $CONDA/bin/python setup.py bdist_wheel
+        $CONDA/bin/delocate-wheel -w fixed_wheels -v  dist/gripy-*
       shell: bash
     - uses: actions/upload-artifact@v2
       with:
         name: 'Artifacts-V2'
-        path: './wheelhouse'
+        path: './fixed_wheels'
       if: matrix.os == 'macos-10.15'
 
     - name: windows install fortran

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: macos install dependencies
       env:
-        DELOCATE_LIBRARY_PATH: .:$CONDA/lib:/usr/local/lib
+        DELOCATE_LIBRARY_PATH: /usr/local/miniconda/lib
       run: |
         $CONDA/bin/python -m pip install git+https://github.com/abrammer/delocate.git
         $CONDA/bin/python -c "import os; print(os.getenv('DELOCATE_LIBRARY_PATH'))"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -42,11 +42,6 @@ jobs:
       if: matrix.os == 'macos-10.15'
 
     - name: Build wheels
-      env:
-        CIBW_BEFORE_BUILD: scripts/build-openssl /tmp/vendor
-        CIBW_ENVIRONMENT: AIOQUIC_SKIP_TESTS=ipv6,loss CFLAGS=-I/tmp/vendor/include LDFLAGS=-L/tmp/vendor/lib
-        CIBW_SKIP: cp27-* cp33-* cp34-* cp35-* pp27-*
-        CIBW_TEST_COMMAND: $CONDA/bin/pytest discover -t {project} -s {project}/tests
       run: |
         $CONDA/bin/pip install cibuildwheel
         $CONDA/bin/cibuildwheel --output-dir dist

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -35,7 +35,8 @@ jobs:
         DYLD_FALLBACK_LIBRARY_PATH: $CONDA/lib:/usr/local/lib
         RPATH: $CONDA/lib:/usr/local/lib
       run: |
-        DYLD_LIBRARY_PATH=/diff; $CONDA/bin/python -c "import os; print(os.getenv('DYLD_LIBRARY_PATH'))"
+        $CONDA/bin/python -m pip install git+https://github.com/abrammer/delocate.git
+        DELOCATE_LIBRARY_PATH=/diff; $CONDA/bin/python -c "import os; print(os.getenv('DELOCATE_LIBRARY_PATH'))"
         # $CONDA/bin/conda install gfortran_osx-64 numpy wheel
         # ln -s $CONDA/bin/gfortran /usr/local/bin/gfortran
         # $CONDA/bin/python -m pip install .

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -38,19 +38,18 @@ jobs:
       run: |
         $CONDA/bin/python -m pip install git+https://github.com/abrammer/delocate.git
         $CONDA/bin/python -c "import os; print(os.getenv('DELOCATE_LIBRARY_PATH'))"
-        # $CONDA/bin/conda install gfortran_osx-64 numpy wheel
-        # ln -s $CONDA/bin/gfortran /usr/local/bin/gfortran
-        # $CONDA/bin/python -m pip install .
-        # $CONDA/bin/python -m pip install -r requirements-test.txt
-        # $CONDA/bin/python -m pip install delocate
-        # $CONDA/bin/python setup.py bdist_wheel
+        $CONDA/bin/conda install gfortran_osx-64 numpy wheel
+        ln -s $CONDA/bin/gfortran /usr/local/bin/gfortran
+        $CONDA/bin/python -m pip install .
+        $CONDA/bin/python -m pip install -r requirements-test.txt
+        $CONDA/bin/python setup.py bdist_wheel
         # which otool
         # which install_name_tool
 
-        # echo "List delocate"
-        # DYLD_LIBRARY_PATH=$CONDA/lib; $CONDA/bin/delocate-listdeps dist/gripy-*
-        # echo "Start delocate"
-        # DYLD_LIBRARY_PATH=$CONDA/lib; $CONDA/bin/delocate-wheel -w fixed_wheels -v  dist/gripy-*
+        echo "List delocate"
+        $CONDA/bin/delocate-listdeps dist/gripy-*
+        echo "Start delocate"
+        $CONDA/bin/delocate-wheel -w fixed_wheels -v  dist/gripy-*
     - uses: actions/upload-artifact@v2
       with:
         name: 'Artifacts-V2'

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -31,10 +31,7 @@ jobs:
 
     - name: macos install dependencies
       env:
-        DYLD_LIBRARY_PATH: $CONDA/lib:/usr/local/lib
-        DELOCATE_LIBRARY_PATH: $CONDA/lib:/usr/local/lib
-        DYLD_FALLBACK_LIBRARY_PATH: $CONDA/lib:/usr/local/lib
-        RPATH: $CONDA/lib:/usr/local/lib
+        DELOCATE_LIBRARY_PATH: .:$CONDA/lib:/usr/local/lib
       run: |
         $CONDA/bin/python -m pip install git+https://github.com/abrammer/delocate.git
         $CONDA/bin/python -c "import os; print(os.getenv('DELOCATE_LIBRARY_PATH'))"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -43,9 +43,8 @@ jobs:
         $CONDA/bin/python setup.py bdist_wheel
         which otool
         which install_name_tool
-        echo $DYLD_LIBRARY_PATH
-        echo $DYLD_FALLBACK_LIBRARY_PATH
-        echo $RPATH
+        ln -s $CONDA/lib/* ./
+        ls
         echo "List delocate"
         $CONDA/bin/delocate-listdeps dist/gripy-*
         echo "Start delocate"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -43,12 +43,11 @@ jobs:
         $CONDA/bin/python setup.py bdist_wheel
         which otool
         which install_name_tool
-        ln -s $CONDA/lib/* ./
-        ls
+
         echo "List delocate"
-        $CONDA/bin/delocate-listdeps dist/gripy-*
+        DYLD_LIBRARY_PATH=$CONDA/lib; $CONDA/bin/delocate-listdeps dist/gripy-*
         echo "Start delocate"
-        $CONDA/bin/delocate-wheel -w fixed_wheels -v  dist/gripy-*
+        DYLD_LIBRARY_PATH=$CONDA/lib; $CONDA/bin/delocate-wheel -w fixed_wheels -v  dist/gripy-*
     - uses: actions/upload-artifact@v2
       with:
         name: 'Artifacts-V2'

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -32,11 +32,12 @@ jobs:
     - name: macos install dependencies
       env:
         DYLD_LIBRARY_PATH: $CONDA/lib:/usr/local/lib
+        DELOCATE_LIBRARY_PATH: /something
         DYLD_FALLBACK_LIBRARY_PATH: $CONDA/lib:/usr/local/lib
         RPATH: $CONDA/lib:/usr/local/lib
       run: |
         $CONDA/bin/python -m pip install git+https://github.com/abrammer/delocate.git
-        DELOCATE_LIBRARY_PATH=/diff; $CONDA/bin/python -c "import os; print(os.getenv('DELOCATE_LIBRARY_PATH'))"
+        $CONDA/bin/python -c "import os; print(os.getenv('DELOCATE_LIBRARY_PATH'))"
         # $CONDA/bin/conda install gfortran_osx-64 numpy wheel
         # ln -s $CONDA/bin/gfortran /usr/local/bin/gfortran
         # $CONDA/bin/python -m pip install .

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-10.15 ]
-        python: [3.6, 3.7, 3.8, 3.9]
+        os: [  macos-10.15 ]
+        python: [ 3.8, ]
 
     steps:
     - uses: actions/checkout@v2
@@ -17,7 +17,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
-    
+
     - name: ubuntu install fortran
       run: sudo apt install gfortran
       if: matrix.os == 'ubuntu-latest'
@@ -41,6 +41,18 @@ jobs:
       run: $CONDA/bin/pytest tests/
       if: matrix.os == 'macos-10.15'
 
+    - name: Build wheels
+      env:
+        CIBW_BEFORE_BUILD: scripts/build-openssl /tmp/vendor
+        CIBW_ENVIRONMENT: AIOQUIC_SKIP_TESTS=ipv6,loss CFLAGS=-I/tmp/vendor/include LDFLAGS=-L/tmp/vendor/lib
+        CIBW_SKIP: cp27-* cp33-* cp34-* cp35-* pp27-*
+        CIBW_TEST_COMMAND: python -m pytest discover -t {project} -s {project}/tests
+      run: |
+        pip install cibuildwheel
+        cibuildwheel --output-dir dist
+      shell: bash
+      if: matrix.os == 'macos-10.15'
+
     - name: windows install fortran
       run: |
         choco install mingw
@@ -50,7 +62,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install . 
+        pip install .
         pip install -r requirements-test.txt
       if: matrix.os != 'macos-10.15'
 
@@ -59,4 +71,3 @@ jobs:
         pip install pytest
         pytest tests/
       if: matrix.os != 'macos-10.15'
-

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -46,10 +46,10 @@ jobs:
         CIBW_BEFORE_BUILD: scripts/build-openssl /tmp/vendor
         CIBW_ENVIRONMENT: AIOQUIC_SKIP_TESTS=ipv6,loss CFLAGS=-I/tmp/vendor/include LDFLAGS=-L/tmp/vendor/lib
         CIBW_SKIP: cp27-* cp33-* cp34-* cp35-* pp27-*
-        CIBW_TEST_COMMAND: python -m pytest discover -t {project} -s {project}/tests
+        CIBW_TEST_COMMAND: $CONDA/bin/pytest discover -t {project} -s {project}/tests
       run: |
-        pip install cibuildwheel
-        cibuildwheel --output-dir dist
+        $CONDA/bin/pip install cibuildwheel
+        $CONDA/bin/cibuildwheel --output-dir dist
       shell: bash
       if: matrix.os == 'macos-10.15'
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [  macos-10.15 ]
-        python: [ 3.8, ]
+        python: [ 3.7, ]
 
     steps:
     - uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
 
     - name: macos install dependencies
       env:
-        DYLD_LIBRARY_PATH: $CONDA/lib
+        DYLD_FALLBACK_LIBRARY_PATH: $CONDA/lib
       run: |
         $CONDA/bin/conda install gfortran_osx-64 numpy wheel
         ln -s $CONDA/bin/gfortran /usr/local/bin/gfortran

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -44,8 +44,8 @@ jobs:
     - name: Build wheels
       env:
         # CIBW_BEFORE_BUILD: scripts/build-openssl /tmp/vendor
-        CIBW_ENVIRONMENT: "PATH=$PATH:$CONDA/bin"
-        CIBW_SKIP: cp27-* cp33-* cp34-* cp35-* pp27-*
+        CIBW_ENVIRONMENT: "PATH=$PATH:$CONDA/bin CFLAGS=-I$CONDA/include LDFLAGS=-L$CONDA/lib"
+        CIBW_SKIP: cp27-* cp3* pp27-* pp34-* pp35-* pp36-* pp38-* pp39-*
         # CIBW_TEST_COMMAND: $CONDA/bin/pytest discover -t {project} -s {project}/tests
       run: |
         $CONDA/bin/pip install cibuildwheel

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -31,7 +31,9 @@ jobs:
 
     - name: macos install dependencies
       env:
-        DYLD_FALLBACK_LIBRARY_PATH: $CONDA/lib
+        DYLD_LIBRARY_PATH: $CONDA/lib:/usr/local/lib
+        DYLD_FALLBACK_LIBRARY_PATH: $CONDA/lib:/usr/local/lib
+        RPATH: $CONDA/lib:/usr/local/lib
       run: |
         $CONDA/bin/conda install gfortran_osx-64 numpy wheel
         ln -s $CONDA/bin/gfortran /usr/local/bin/gfortran
@@ -39,9 +41,11 @@ jobs:
         $CONDA/bin/python -m pip install -r requirements-test.txt
         $CONDA/bin/python -m pip install delocate
         $CONDA/bin/python setup.py bdist_wheel
-        ln -s $CONDA/lib @rpath
         which otool
         which install_name_tool
+        echo $DYLD_LIBRARY_PATH
+        echo $DYLD_FALLBACK_LIBRARY_PATH
+        echo $RPATH
         echo "List delocate"
         $CONDA/bin/delocate-listdeps dist/gripy-*
         echo "Start delocate"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -35,19 +35,20 @@ jobs:
         DYLD_FALLBACK_LIBRARY_PATH: $CONDA/lib:/usr/local/lib
         RPATH: $CONDA/lib:/usr/local/lib
       run: |
-        $CONDA/bin/conda install gfortran_osx-64 numpy wheel
-        ln -s $CONDA/bin/gfortran /usr/local/bin/gfortran
-        $CONDA/bin/python -m pip install .
-        $CONDA/bin/python -m pip install -r requirements-test.txt
-        $CONDA/bin/python -m pip install delocate
-        $CONDA/bin/python setup.py bdist_wheel
-        which otool
-        which install_name_tool
+        DYLD_LIBRARY_PATH=/diff; $CONDA/bin/python -c "import os; print(os.getenv('DYLD_LIBRARY_PATH'))"
+        # $CONDA/bin/conda install gfortran_osx-64 numpy wheel
+        # ln -s $CONDA/bin/gfortran /usr/local/bin/gfortran
+        # $CONDA/bin/python -m pip install .
+        # $CONDA/bin/python -m pip install -r requirements-test.txt
+        # $CONDA/bin/python -m pip install delocate
+        # $CONDA/bin/python setup.py bdist_wheel
+        # which otool
+        # which install_name_tool
 
-        echo "List delocate"
-        DYLD_LIBRARY_PATH=$CONDA/lib; $CONDA/bin/delocate-listdeps dist/gripy-*
-        echo "Start delocate"
-        DYLD_LIBRARY_PATH=$CONDA/lib; $CONDA/bin/delocate-wheel -w fixed_wheels -v  dist/gripy-*
+        # echo "List delocate"
+        # DYLD_LIBRARY_PATH=$CONDA/lib; $CONDA/bin/delocate-listdeps dist/gripy-*
+        # echo "Start delocate"
+        # DYLD_LIBRARY_PATH=$CONDA/lib; $CONDA/bin/delocate-wheel -w fixed_wheels -v  dist/gripy-*
     - uses: actions/upload-artifact@v2
       with:
         name: 'Artifacts-V2'

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -44,6 +44,7 @@ jobs:
         $CONDA/bin/delocate-wheel -w fixed_wheels -v  dist/gripy-*
     - uses: actions/upload-artifact@v2
       with:
+        name: macos_cp${{ matrix.python }}_wheel
         path: './fixed_wheels'
       if: matrix.os == 'macos-10.15'
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [  macos-10.15 ]
+        os: [ ubuntu-latest, macos-10.15 ]
         python: [ 3.6,3.7,3.8 ]
 
     steps:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [  macos-10.15 ]
-        python: [ 3.7, ]
+        python: [ 3.6,3.7,3.8 ]
 
     steps:
     - uses: actions/checkout@v2
@@ -40,16 +40,10 @@ jobs:
         $CONDA/bin/python -m pip install .
         $CONDA/bin/python -m pip install -r requirements-test.txt
         $CONDA/bin/python setup.py bdist_wheel
-        # which otool
-        # which install_name_tool
-
-        echo "List delocate"
-        $CONDA/bin/delocate-listdeps dist/gripy-*
         echo "Start delocate"
         $CONDA/bin/delocate-wheel -w fixed_wheels -v  dist/gripy-*
     - uses: actions/upload-artifact@v2
       with:
-        name: 'Artifacts-V2'
         path: './fixed_wheels'
       if: matrix.os == 'macos-10.15'
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -30,22 +30,12 @@ jobs:
       if: matrix.os == 'macos-10.15'
 
     - name: macos install dependencies
-      env:
-        DELOCATE_LIBRARY_PATH: /usr/local/miniconda/lib
       run: |
-        $CONDA/bin/python -m pip install git+https://github.com/abrammer/delocate.git
-        $CONDA/bin/python -c "import os; print(os.getenv('DELOCATE_LIBRARY_PATH'))"
         $CONDA/bin/conda install gfortran_osx-64 numpy wheel
         ln -s $CONDA/bin/gfortran /usr/local/bin/gfortran
         $CONDA/bin/python -m pip install .
         $CONDA/bin/python -m pip install -r requirements-test.txt
-        $CONDA/bin/python setup.py bdist_wheel
-        echo "Start delocate"
-        $CONDA/bin/delocate-wheel -w fixed_wheels -v  dist/gripy-*
-    - uses: actions/upload-artifact@v2
-      with:
-        name: macos_cp${{ matrix.python }}_wheel
-        path: './fixed_wheels'
+
       if: matrix.os == 'macos-10.15'
 
     - name: macos run tests

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-10.15 ]
-        python: [ 3.6,3.7,3.8 ]
+        python: [ 3.6, 3.7, 3.8, 3.9 ]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -40,6 +40,8 @@ jobs:
         $CONDA/bin/python -m pip install delocate
         $CONDA/bin/python setup.py bdist_wheel
         ln -s $CONDA/lib @rpath
+        which otool
+        which install_name_tool
         echo "List delocate"
         $CONDA/bin/delocate-listdeps dist/gripy-*
         echo "Start delocate"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -36,21 +36,17 @@ jobs:
         $CONDA/bin/python -m pip install .
         $CONDA/bin/python -m pip install -r requirements-test.txt
         $CONDA/bin/python -m pip install delocate
-      if: matrix.os == 'macos-10.15'
-
-    - name: macos run tests
-      run: $CONDA/bin/pytest tests/
-      if: matrix.os == 'macos-10.15'
-
-    - name: Build wheels
-      run: |
         $CONDA/bin/python setup.py bdist_wheel
+        $CONDA/bin/delocate-listdeps dist/gripy-*
         $CONDA/bin/delocate-wheel -w fixed_wheels -v  dist/gripy-*
-      shell: bash
     - uses: actions/upload-artifact@v2
       with:
         name: 'Artifacts-V2'
         path: './fixed_wheels'
+      if: matrix.os == 'macos-10.15'
+
+    - name: macos run tests
+      run: $CONDA/bin/pytest tests/
       if: matrix.os == 'macos-10.15'
 
     - name: windows install fortran

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -30,6 +30,8 @@ jobs:
       if: matrix.os == 'macos-10.15'
 
     - name: macos install dependencies
+      env:
+        DYLD_LIBRARY_PATH: $CONDA/lib
       run: |
         $CONDA/bin/conda install gfortran_osx-64 numpy wheel
         ln -s $CONDA/bin/gfortran /usr/local/bin/gfortran

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -39,6 +39,7 @@ jobs:
         $CONDA/bin/python -m pip install -r requirements-test.txt
         $CONDA/bin/python -m pip install delocate
         $CONDA/bin/python setup.py bdist_wheel
+        ln -s $CONDA/lib @rpath
         echo "List delocate"
         $CONDA/bin/delocate-listdeps dist/gripy-*
         echo "Start delocate"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -42,10 +42,19 @@ jobs:
       if: matrix.os == 'macos-10.15'
 
     - name: Build wheels
+      env:
+        # CIBW_BEFORE_BUILD: scripts/build-openssl /tmp/vendor
+        # CIBW_ENVIRONMENT: AIOQUIC_SKIP_TESTS=ipv6,loss CFLAGS=-I/tmp/vendor/include LDFLAGS=-L/tmp/vendor/lib
+        CIBW_SKIP: cp27-* cp33-* cp34-* cp35-* pp27-*
+        # CIBW_TEST_COMMAND: $CONDA/bin/pytest discover -t {project} -s {project}/tests
       run: |
         $CONDA/bin/pip install cibuildwheel
-        $CONDA/bin/cibuildwheel --output-dir dist
+        $CONDA/bin/cibuildwheel --output-dir ./wheelhouse
       shell: bash
+    - uses: actions/upload-artifact@v2
+      with:
+        name: 'Artifacts-V2'
+        path: './wheelhouse'
       if: matrix.os == 'macos-10.15'
 
     - name: windows install fortran

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -32,7 +32,7 @@ jobs:
     - name: macos install dependencies
       env:
         DYLD_LIBRARY_PATH: $CONDA/lib:/usr/local/lib
-        DELOCATE_LIBRARY_PATH: /something
+        DELOCATE_LIBRARY_PATH: $CONDA/lib:/usr/local/lib
         DYLD_FALLBACK_LIBRARY_PATH: $CONDA/lib:/usr/local/lib
         RPATH: $CONDA/lib:/usr/local/lib
       run: |

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,6 @@
+import setuptools
+from distutils.core import setup
+
 from distutils.command.sdist import sdist
 try:
     from numpy.distutils.core import setup, Extension


### PR DESCRIPTION
Jumped through a lot of hoops to work out how to automate Mac wheel builds within a conda env.  Using a custom fork of delocate package to subvert Mac purging dyld_library_path environment variables.  